### PR TITLE
トレーニング記録一覧画面の初期表示時にトレーニング記録開始時刻に現在時刻が設定されるようにする

### DIFF
--- a/src/main/java/com/iwatakhr/mslmgt/presentation/controller/TrgRecordListRegistEditController.java
+++ b/src/main/java/com/iwatakhr/mslmgt/presentation/controller/TrgRecordListRegistEditController.java
@@ -1,5 +1,7 @@
 package com.iwatakhr.mslmgt.presentation.controller;
 
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -35,10 +37,16 @@ public class TrgRecordListRegistEditController {
 	@GetMapping("/show")
 	public String show(TrgRecordListRegistEditForm form, Model model) {
 		
-		model.addAttribute("trgRecordListRegistEdit", new TrgRecordListRegistEditForm());
+		// 初期表示時のデフォルト設定
+		// 開始時刻（「yyyyMMddHHmm」までを指定）
+		LocalDateTime defaultStartTime = LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES);
+		form.setTrainingStartTime(defaultStartTime);
+		
+		model.addAttribute("trgRecordListRegistEdit", form);
 		model.addAttribute("EventsName_SelectList", MockValue.EventsName_SelectList);
 		return "/mslmgt/trgRecordListRegistEdit";
 	}
+
 
 	/**
 	 * 初期表示

--- a/src/main/resources/templates/mslmgt/trgRecordListRegistEdit.html
+++ b/src/main/resources/templates/mslmgt/trgRecordListRegistEdit.html
@@ -47,7 +47,7 @@
 		<!-- 日付 -->
 		<div class="form-group">
 			<label class="control-label ">トレーニング開始日時：</label><br>
-			<input type="datetime-local" name="trainingStartTime" step="60" />
+			<input type="datetime-local" name="trainingStartTime"  th:field="*{trainingStartTime}" step="60" />
 		</div>
 		
 		<!-- 詳細List -->


### PR DESCRIPTION
レビュー担当へ

以下対応のレビューをお願いします。
>トレーニング記録一覧画面でトレーニング開始時間はデフォルトで今の日付を設定する

テストデータがある場合は、ここになにか書く？


